### PR TITLE
Replace the default implementation of JPA hibernate to openjpa

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
         <takari-maven-plugin.version>0.6.1</takari-maven-plugin.version>
+        <openjpa.version>3.1.2</openjpa.version>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
     
@@ -54,6 +55,11 @@
                 <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.openjpa</groupId>
+                <artifactId>openjpa</artifactId>
+                <version>${openjpa.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-backend/pom.xml
+++ b/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-backend/pom.xml
@@ -27,8 +27,7 @@
     <name>${project.artifactId}</name>
     
     <properties>
-        <spring-boot.version>2.3.1.RELEASE</spring-boot.version>
-        <springframework.version>5.2.7.RELEASE</springframework.version>
+        <springframework.version>4.3.24.RELEASE</springframework.version>
         <commons-dbcp.version>1.4</commons-dbcp.version>
     </properties>
     
@@ -42,6 +41,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,7 +56,19 @@
                     <groupId>javax.transaction</groupId>
                     <artifactId>javax.transaction-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-entitymanager</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.openjpa</groupId>
+            <artifactId>openjpa</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/cloud/ui/config/BeanConfiguration.java
+++ b/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/cloud/ui/config/BeanConfiguration.java
@@ -52,7 +52,7 @@ public class BeanConfiguration {
     
     @Bean
     public CoordinatorRegistryCenter regCenter() {
-        CoordinatorRegistryCenter registryCenter = new ZookeeperRegistryCenter(BootstrapEnvironment.getINSTANCE().getZookeeperConfiguration());
+        CoordinatorRegistryCenter registryCenter = new ZookeeperRegistryCenter(BootstrapEnvironment.getInstance().getZookeeperConfiguration());
         registryCenter.init();
         return registryCenter;
     }
@@ -89,7 +89,7 @@ public class BeanConfiguration {
     
     @Bean
     public StatisticManager statisticManager() {
-        return StatisticManager.getInstance(regCenter(), BootstrapEnvironment.getINSTANCE().getTracingConfiguration().orElse(null));
+        return StatisticManager.getInstance(regCenter(), BootstrapEnvironment.getInstance().getTracingConfiguration().orElse(null));
     }
     
     @Bean
@@ -109,7 +109,7 @@ public class BeanConfiguration {
     
     @Bean
     public JobEventBus jobEventBus() {
-        Optional<TracingConfiguration> tracingConfiguration = BootstrapEnvironment.getINSTANCE().getTracingConfiguration();
+        Optional<TracingConfiguration> tracingConfiguration = BootstrapEnvironment.getInstance().getTracingConfiguration();
         return tracingConfiguration.map(JobEventBus::new).orElseGet(JobEventBus::new);
     }
     
@@ -117,23 +117,23 @@ public class BeanConfiguration {
     public SchedulerDriver schedulerDriver() {
         Protos.FrameworkInfo.Builder builder = Protos.FrameworkInfo.newBuilder();
         frameworkIDService().fetch().ifPresent(frameworkID -> builder.setId(Protos.FrameworkID.newBuilder().setValue(frameworkID).build()));
-        Optional<String> role = BootstrapEnvironment.getINSTANCE().getMesosRole();
+        Optional<String> role = BootstrapEnvironment.getInstance().getMesosRole();
         String frameworkName = MesosConfiguration.FRAMEWORK_NAME;
         if (role.isPresent()) {
             builder.setRole(role.get());
             frameworkName += "-" + role.get();
         }
         builder.addCapabilitiesBuilder().setType(Protos.FrameworkInfo.Capability.Type.PARTITION_AWARE);
-        MesosConfiguration mesosConfig = BootstrapEnvironment.getINSTANCE().getMesosConfiguration();
+        MesosConfiguration mesosConfig = BootstrapEnvironment.getInstance().getMesosConfiguration();
         Protos.FrameworkInfo frameworkInfo = builder.setUser(mesosConfig.getUser()).setName(frameworkName)
                 .setHostname(mesosConfig.getHostname()).setFailoverTimeout(MesosConfiguration.FRAMEWORK_FAILOVER_TIMEOUT_SECONDS)
-                .setWebuiUrl(WEB_UI_PROTOCOL + BootstrapEnvironment.getINSTANCE().getFrameworkHostPort()).setCheckpoint(true).build();
+                .setWebuiUrl(WEB_UI_PROTOCOL + BootstrapEnvironment.getInstance().getFrameworkHostPort()).setCheckpoint(true).build();
         return new MesosSchedulerDriver(new SchedulerEngine(taskScheduler(), facadeService(), jobEventBus(), frameworkIDService(), statisticManager()), frameworkInfo, mesosConfig.getUrl());
     }
     
     @Bean
     public JobEventRdbSearch jobEventRdbSearch() {
-        Optional<TracingConfiguration> tracingConfiguration = BootstrapEnvironment.getINSTANCE().getTracingConfiguration();
+        Optional<TracingConfiguration> tracingConfiguration = BootstrapEnvironment.getInstance().getTracingConfiguration();
         return tracingConfiguration.map(each -> new JobEventRdbSearch((DataSource) each.getStorage(), true)).orElse(new JobEventRdbSearch(null, false));
     }
 }

--- a/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/cloud/ui/config/DynamicDataSourceConfig.java
+++ b/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/cloud/ui/config/DynamicDataSourceConfig.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.cloud.ui.config;
 
 import org.apache.commons.dbcp.BasicDataSource;
-import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;

--- a/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/cloud/ui/config/OpenJPAConfig.java
+++ b/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/cloud/ui/config/OpenJPAConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.cloud.ui.config;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
+import org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.vendor.AbstractJpaVendorAdapter;
+import org.springframework.orm.jpa.vendor.OpenJpaVendorAdapter;
+import org.springframework.transaction.jta.JtaTransactionManager;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableConfigurationProperties(JpaProperties.class)
+public class OpenJPAConfig extends JpaBaseConfiguration {
+    
+    protected OpenJPAConfig(DataSource dataSource,
+                            JpaProperties properties,
+                            ObjectProvider<JtaTransactionManager> jtaTransactionManager,
+                            ObjectProvider<TransactionManagerCustomizers> transactionManagerCustomizers) {
+        super(dataSource, properties, jtaTransactionManager, transactionManagerCustomizers);
+    }
+    
+    @Override
+    protected AbstractJpaVendorAdapter createJpaVendorAdapter() {
+        return new OpenJpaVendorAdapter();
+    }
+    
+    @Override
+    protected Map<String, Object> getVendorProperties() {
+        final Map<String, Object> result = new HashMap<>();
+        result.put("openjpa.jdbc.SynchronizeMappings", "buildSchema(ForeignKeys=true)");
+        result.put("openjpa.ClassLoadEnhancement", "false");
+        result.put("openjpa.DynamicEnhancementAgent", "false");
+        result.put("openjpa.RuntimeUnenhancedClasses", "supported");
+        return result;
+    }
+    
+}

--- a/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-backend/src/main/resources/application.properties
+++ b/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-backend/src/main/resources/application.properties
@@ -26,5 +26,4 @@ spring.datasource.default.driver-class-name=org.h2.Driver
 spring.datasource.default.url=jdbc:h2:mem:
 spring.datasource.default.username=sa
 spring.datasource.default.password=
-spring.jpa.database-platform=org.hibernate.dialect.HSQLDialect
 spring.jpa.show-sql=false

--- a/shardingsphere-elasticjob-lite-ui/pom.xml
+++ b/shardingsphere-elasticjob-lite-ui/pom.xml
@@ -23,7 +23,6 @@
         <artifactId>shardingsphere-elasticjob-ui</artifactId>
         <version>3.0.0-alpha-SNAPSHOT</version>
     </parent>
-    <groupId>org.apache.shardingsphere</groupId>
     <artifactId>shardingsphere-elasticjob-lite-ui</artifactId>
     <version>3.0.0-alpha-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/pom.xml
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/pom.xml
@@ -27,8 +27,7 @@
     <name>${project.artifactId}</name>
     
     <properties>
-        <spring-boot.version>2.3.1.RELEASE</spring-boot.version>
-        <springframework.version>5.2.7.RELEASE</springframework.version>
+        <springframework.version>4.3.24.RELEASE</springframework.version>
         <commons-dbcp.version>1.4</commons-dbcp.version>
     </properties>
     
@@ -42,6 +41,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,7 +56,19 @@
                     <groupId>javax.transaction</groupId>
                     <artifactId>javax.transaction-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-entitymanager</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.openjpa</groupId>
+            <artifactId>openjpa</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/Bootstrap.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/Bootstrap.java
@@ -36,4 +36,5 @@ public class Bootstrap {
     //CHECKSTYLE:ON
         SpringApplication.run(Bootstrap.class, args);
     }
+    
 }

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/config/DynamicDataSourceConfig.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/config/DynamicDataSourceConfig.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.lite.ui.config;
 
 import org.apache.commons.dbcp.BasicDataSource;
-import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/config/OpenJPAConfig.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/config/OpenJPAConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.elasticjob.lite.ui.config;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
+import org.springframework.boot.autoconfigure.transaction.TransactionManagerCustomizers;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.vendor.AbstractJpaVendorAdapter;
+import org.springframework.orm.jpa.vendor.OpenJpaVendorAdapter;
+import org.springframework.transaction.jta.JtaTransactionManager;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableConfigurationProperties(JpaProperties.class)
+public class OpenJPAConfig extends JpaBaseConfiguration {
+    
+    protected OpenJPAConfig(DataSource dataSource,
+                            JpaProperties properties,
+                            ObjectProvider<JtaTransactionManager> jtaTransactionManager,
+                            ObjectProvider<TransactionManagerCustomizers> transactionManagerCustomizers) {
+        super(dataSource, properties, jtaTransactionManager, transactionManagerCustomizers);
+    }
+    
+    @Override
+    protected AbstractJpaVendorAdapter createJpaVendorAdapter() {
+        return new OpenJpaVendorAdapter();
+    }
+    
+    @Override
+    protected Map<String, Object> getVendorProperties() {
+        final Map<String, Object> result = new HashMap<>();
+        result.put("openjpa.jdbc.SynchronizeMappings", "buildSchema(ForeignKeys=true)");
+        result.put("openjpa.ClassLoadEnhancement", "false");
+        result.put("openjpa.DynamicEnhancementAgent", "false");
+        result.put("openjpa.RuntimeUnenhancedClasses", "supported");
+        return result;
+    }
+    
+}

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/dao/statistics/JobRegisterStatisticsRepository.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/dao/statistics/JobRegisterStatisticsRepository.java
@@ -38,6 +38,6 @@ public interface JobRegisterStatisticsRepository extends JpaRepository<JobRegist
      * @param fromTime from date to statistics
      * @return job register statistics
      */
-    @Query("FROM JobRegisterStatistics WHERE statisticsTime >= :fromTime")
+    @Query("SELECT t FROM JobRegisterStatistics t WHERE t.statisticsTime >= :fromTime")
     List<JobRegisterStatistics> findJobRegisterStatistics(@Param("fromTime") Date fromTime);
 }

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/dao/statistics/JobRunningStatisticsRepository.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/dao/statistics/JobRunningStatisticsRepository.java
@@ -38,6 +38,6 @@ public interface JobRunningStatisticsRepository extends JpaRepository<JobRunning
      * @param fromTime from date to statistics
      * @return job running statistics
      */
-    @Query("FROM JobRunningStatistics WHERE statisticsTime >= :fromTime")
+    @Query("SELECT t FROM JobRunningStatistics t WHERE t.statisticsTime >= :fromTime")
     List<JobRunningStatistics> findJobRunningStatistics(@Param("fromTime") Date fromTime);
 }

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/dao/statistics/TaskResultStatisticsRepository.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/dao/statistics/TaskResultStatisticsRepository.java
@@ -39,7 +39,7 @@ public interface TaskResultStatisticsRepository extends JpaRepository<TaskResult
      * @param statisticInterval statistic interval
      * @return task result statistics
      */
-    @Query("FROM TaskResultStatistics WHERE statisticInterval = :statisticInterval AND statisticsTime >= :fromTime ORDER BY id ASC")
+    @Query("SELECT t FROM TaskResultStatistics t WHERE t.statisticInterval = :statisticInterval AND t.statisticsTime >= :fromTime ORDER BY t.id ASC")
     List<TaskResultStatistics> findTaskResultStatistics(@Param("fromTime") Date fromTime, @Param("statisticInterval") String statisticInterval);
     
     /**
@@ -49,7 +49,7 @@ public interface TaskResultStatisticsRepository extends JpaRepository<TaskResult
      * @param statisticInterval statistic interval
      * @return summed task result statistics
      */
-    @Query("SELECT new TaskResultStatistics(SUM(successCount), SUM(failedCount)) FROM TaskResultStatistics WHERE "
-        + "statisticInterval = :statisticInterval AND statisticsTime >= :fromTime")
+    @Query("SELECT new TaskResultStatistics(SUM(t.successCount), SUM(t.failedCount)) FROM TaskResultStatistics t WHERE "
+        + "t.statisticInterval = :statisticInterval AND t.statisticsTime >= :fromTime")
     TaskResultStatistics getSummedTaskResultStatistics(@Param("fromTime") Date fromTime, @Param("statisticInterval") String statisticInterval);
 }

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/dao/statistics/TaskRunningStatisticsRepository.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/dao/statistics/TaskRunningStatisticsRepository.java
@@ -38,6 +38,6 @@ public interface TaskRunningStatisticsRepository extends JpaRepository<TaskRunni
      * @param fromTime from date to statistics
      * @return Task running statistics
      */
-    @Query("FROM TaskRunningStatistics where statisticsTime >= :fromTime")
+    @Query("SELECT t FROM TaskRunningStatistics t where t.statisticsTime >= :fromTime")
     List<TaskRunningStatistics> findTaskRunningStatistics(@Param("fromTime") Date fromTime);
 }

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/domain/DataSourceFactory.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/domain/DataSourceFactory.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.elasticjob.lite.ui.domain;
 
 import org.apache.commons.dbcp.BasicDataSource;
-import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceBuilder;
 
 import javax.sql.DataSource;
 

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/domain/JobRegisterStatistics.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/domain/JobRegisterStatistics.java
@@ -37,7 +37,7 @@ import java.util.Date;
 @AllArgsConstructor
 @Entity
 @Table(name = "JOB_REGISTER_STATISTICS")
-public final class JobRegisterStatistics {
+public class JobRegisterStatistics {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/domain/JobRunningStatistics.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/domain/JobRunningStatistics.java
@@ -37,7 +37,7 @@ import java.util.Date;
 @AllArgsConstructor
 @Entity
 @Table(name = "JOB_RUNNING_STATISTICS")
-public final class JobRunningStatistics {
+public class JobRunningStatistics {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/domain/TaskResultStatistics.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/domain/TaskResultStatistics.java
@@ -37,7 +37,7 @@ import java.util.Date;
 @NoArgsConstructor
 @Entity
 @Table(name = "TASK_RESULT_STATISTICS")
-public final class TaskResultStatistics {
+public class TaskResultStatistics {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/domain/TaskRunningStatistics.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/domain/TaskRunningStatistics.java
@@ -37,7 +37,7 @@ import java.util.Date;
 @AllArgsConstructor
 @Entity
 @Table(name = "TASK_RUNNING_STATISTICS")
-public final class TaskRunningStatistics {
+public class TaskRunningStatistics {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/resources/application.properties
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/resources/application.properties
@@ -26,5 +26,4 @@ spring.datasource.default.driver-class-name=org.h2.Driver
 spring.datasource.default.url=jdbc:h2:mem:
 spring.datasource.default.username=sa
 spring.datasource.default.password=
-spring.jpa.database-platform=org.hibernate.dialect.HSQLDialect
 spring.jpa.show-sql=false


### PR DESCRIPTION
Fixes [#1274](https://github.com/apache/shardingsphere-elasticjob/issues/1274).

Change:
- JPA default implementation configuration
- Partially incompatible JPA query syntax