### PR TITLE
Update parent image in Dockerfile

### DIFF
--- a/shardingsphere-elasticjob-ui-distribution/shardingsphere-elasticjob-cloud-ui-bin-distribution/Dockerfile
+++ b/shardingsphere-elasticjob-ui-distribution/shardingsphere-elasticjob-cloud-ui-bin-distribution/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM java:8
+FROM openjdk:8-jre-slim
 MAINTAINER ShardingSphere "dev@shardingsphere.apache.org"
 
 ARG APP_NAME

--- a/shardingsphere-elasticjob-ui-distribution/shardingsphere-elasticjob-lite-ui-bin-distribution/Dockerfile
+++ b/shardingsphere-elasticjob-ui-distribution/shardingsphere-elasticjob-lite-ui-bin-distribution/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM java:8
+FROM openjdk:8-jre-slim
 MAINTAINER ShardingSphere "dev@shardingsphere.apache.org"
 
 ARG APP_NAME


### PR DESCRIPTION
Fixes #47 .

Update parent image from 'java:8' to 'openjdk:8-jre-slim'.