### PR TITLE
Exclude .flattened-pom.xml from src distribution

### DIFF
--- a/shardingsphere-elasticjob-ui-distribution/shardingsphere-elasticjob-ui-src-distribution/src/main/assembly/shardingsphere-elasticjob-ui-src-distribution.xml
+++ b/shardingsphere-elasticjob-ui-distribution/shardingsphere-elasticjob-ui-src-distribution/src/main/assembly/shardingsphere-elasticjob-ui-src-distribution.xml
@@ -50,6 +50,7 @@
                 <exclude>**/pom.xml.releaseBackup</exclude>
                 <exclude>**/cobertura.ser</exclude>
                 <exclude>*.gpg</exclude>
+                <exclude>**/.flattened-pom.xml</exclude>
                 
                 <!-- node ignore -->
                 <exclude>**/shardingsphere-elasticjob-lite-ui-frontend/test/coverage/**</exclude>


### PR DESCRIPTION
Changes proposed in this pull request:
- Exclude .flattened-pom.xml from src distribution.
