### PR TITLE
Could org.apache.shardingsphere:shardingsphere-elasticjob-cloud-ui-frontend:3.1.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-frontend/pom.xml
+++ b/shardingsphere-elasticjob-cloud-ui/shardingsphere-elasticjob-cloud-ui-frontend/pom.xml
@@ -161,4 +161,27 @@
             </build>
         </profile>
     </profiles>
+    <dependencies>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.11</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>1.7.26</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>1.7.26</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/163949514-dc2863a9-f7d3-41d6-bb89-4879d859008e.png)
This figure presents the dependency tree between multiple modules in **_shardingsphere-elasticjob-cloud-ui_**. As shown in this figure, Libraries
##
org.slf4j:jcl-over-slf4j:jar:1.7.26:compile
org.slf4j:log4j-over-slf4j:jar:1.7.26:compile
ch.qos.logback:logback-classic:jar:1.1.11:compile
ch.qos.logback:logback-core:jar:1.1.11:compile
## Vulnerable libraries
ch.qos.logback:logback-classic:1.1.11 (CVE-2017-5929)
ch.qos.logback:logback-core:1.1.11 (CVE-2021-42550)

## Outdated dependencies
ch.qos.logback:logback-classic:1.1.11 (**_2341_** days without maintenance)
org.slf4j:jcl-over-slf4j:1.7.26 (**_1622_** days without maintenance)

---
in **_shardingsphere-elasticjob-cloud-ui-frontend_** and **_shardingsphere-elasticjob-cloud-ui-backend_** are inherited from their parent module. However, it is only actually used by **_shardingsphere-elasticjob-cloud-ui-backend_**. We can perform refactoring operations in the pom, by removing such redundant dependencies in **_shardingsphere-elasticjob-cloud-ui-frontend_**.

Specifically, the scope of **_org.slf4j:jcl-over-slf4j:jar:1.7.26, org.slf4j:log4j-over-slf4j:jar:1.7.26, ch.qos.logback:logback-classic:jar:1.1.11_**  in **_shardingsphere-elasticjob-cloud-ui-frontend_** can be changed from **_compile_** to **_provided_**. The revisions in the pom are described as follows:
![image](https://user-images.githubusercontent.com/78527112/163950151-5f3048d0-25a8-422b-bd74-20d3288d8187.png)
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_ch.qos.logback:logback-core:jar:1.1.11:compile_** incorporates a medium-level vulnerability SNYK-JAVA-CHQOSLOGBACK-1726923. As such, I suggest a refactoring operation for **_org.apache.shardingsphere:shardingsphere-elasticjob-cloud-ui-frontend:3.1.0-SNAPSHOT_**’s pom file.