### PR TITLE
feat: add support for Casdoor authentication

### DIFF
--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/pom.xml
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/pom.xml
@@ -79,6 +79,11 @@
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.casbin</groupId>
+            <artifactId>casdoor-spring-boot-starter</artifactId>
+            <version>1.3.0</version>
+        </dependency>
     </dependencies>
     
     <build>

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/security/AuthenticationFilter.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/security/AuthenticationFilter.java
@@ -76,7 +76,11 @@ public final class AuthenticationFilter implements Filter {
             return;
         }
         String accessToken = httpRequest.getHeader("Access-Token");
-        if (Strings.isNullOrEmpty(accessToken) || (!userAuthenticationService.isValidToken(accessToken)&& casdoorAuthService.parseJwtToken(accessToken) == null)) {
+        if (Strings.isNullOrEmpty(accessToken)) {
+            respondWithUnauthorized(httpResponse);
+            return;
+        }
+        if(!userAuthenticationService.isValidToken(accessToken)|| casdoorAuthService.parseJwtToken(accessToken) == null){
             respondWithUnauthorized(httpResponse);
             return;
         }
@@ -130,7 +134,6 @@ public final class AuthenticationFilter implements Filter {
             Map<String, Object> result = new HashMap<>(4, 1);
             result.put("username", user.getName());
             result.put("accessToken", token);
-            result.put("isGuest", false);
             objectMapper.writeValue(httpResponse.getWriter(), ResponseResultUtil.build(result));
         } catch (IOException e) {
             e.printStackTrace();

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/security/AuthenticationFilter.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/security/AuthenticationFilter.java
@@ -21,13 +21,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import lombok.Setter;
 import org.apache.shardingsphere.elasticjob.lite.ui.web.response.ResponseResultUtil;
+import org.casbin.casdoor.config.CasdoorConfiguration;
+import org.casbin.casdoor.entity.CasdoorUser;
+import org.casbin.casdoor.service.CasdoorAuthService;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -40,14 +40,23 @@ import java.util.Map;
 public final class AuthenticationFilter implements Filter {
     
     private static final String LOGIN_URI = "/api/login";
-    
+
+    private static final String CASDOOR_LOGIN_URL = "/api/casdoor-login-url";
+
+    private static final String CASDOOR_LOGIN = "/api/casdoor-login";
     private final ObjectMapper objectMapper = new ObjectMapper();
     
     @Setter
     private UserAuthenticationService userAuthenticationService;
-    
+
+    private CasdoorAuthService casdoorAuthService;
+
     @Override
     public void init(final FilterConfig filterConfig) {
+        ServletContext servletContext = filterConfig.getServletContext();
+        ApplicationContext ctx = WebApplicationContextUtils.getWebApplicationContext(servletContext);
+        CasdoorConfiguration config = ctx.getBean(CasdoorConfiguration.class);
+        casdoorAuthService = new CasdoorAuthService(config);
     }
     
     @Override
@@ -58,8 +67,16 @@ public final class AuthenticationFilter implements Filter {
             handleLogin(httpRequest, httpResponse);
             return;
         }
+        if (CASDOOR_LOGIN_URL.equals(httpRequest.getRequestURI())) {
+            handleCasdoorLoginUrl(httpRequest, httpResponse);
+            return;
+        }
+        if (CASDOOR_LOGIN.equals(httpRequest.getRequestURI())) {
+            handleCasdoorLogin(httpRequest, httpResponse);
+            return;
+        }
         String accessToken = httpRequest.getHeader("Access-Token");
-        if (Strings.isNullOrEmpty(accessToken) || !userAuthenticationService.isValidToken(accessToken)) {
+        if (Strings.isNullOrEmpty(accessToken) || (!userAuthenticationService.isValidToken(accessToken)&& casdoorAuthService.parseJwtToken(accessToken) == null)) {
             respondWithUnauthorized(httpResponse);
             return;
         }
@@ -88,7 +105,38 @@ public final class AuthenticationFilter implements Filter {
             e.printStackTrace();
         }
     }
-    
+
+    private void handleCasdoorLoginUrl(final HttpServletRequest httpRequest, final HttpServletResponse httpResponse) {
+        try {
+            String origin = httpRequest.getParameter("origin");
+            String url = casdoorAuthService.getSigninUrl(origin + "/login/casdoor");
+            httpResponse.setContentType("application/json");
+            httpResponse.setCharacterEncoding("UTF-8");
+            Map<String, Object> result = new HashMap<>(1, 1);
+            result.put("casdoorLoginUrl", url);
+            objectMapper.writeValue(httpResponse.getWriter(), ResponseResultUtil.build(result));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void handleCasdoorLogin(final HttpServletRequest httpRequest, final HttpServletResponse httpResponse) {
+        try {
+            OAuthCode code = objectMapper.readValue(httpRequest.getReader(), OAuthCode.class);
+            String token = casdoorAuthService.getOAuthToken(code.getCode(), code.getState());
+            CasdoorUser user = casdoorAuthService.parseJwtToken(token);
+            httpResponse.setContentType("application/json");
+            httpResponse.setCharacterEncoding("UTF-8");
+            Map<String, Object> result = new HashMap<>(4, 1);
+            result.put("username", user.getName());
+            result.put("accessToken", token);
+            result.put("isGuest", false);
+            objectMapper.writeValue(httpResponse.getWriter(), ResponseResultUtil.build(result));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
     private void respondWithUnauthorized(final HttpServletResponse httpResponse) throws IOException {
         httpResponse.setContentType("application/json");
         httpResponse.setCharacterEncoding("UTF-8");

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/security/OAuthCode.java
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/java/org/apache/shardingsphere/elasticjob/lite/ui/security/OAuthCode.java
@@ -15,10 +15,19 @@
  * limitations under the License.
  */
 
-import API from '@/utils/api'
+package org.apache.shardingsphere.elasticjob.lite.ui.security;
 
-export default {
-  getLogin: (params = {}) => API.post(`/api/login`, params),
-  getCasdoorLoginUrl: (params = {}) => API.get(`/api/casdoor-login-url`, params),
-  getCasdoorLogin: (params = {}) => API.post(`/api/casdoor-login`, params)
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * OAuth code
+ **/
+@Getter
+@Setter
+public final class OAuthCode {
+
+    private String code;
+
+    private String state;
 }

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/resources/application.properties
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-backend/src/main/resources/application.properties
@@ -29,3 +29,39 @@ spring.jpa.show-sql=false
 
 ## Uncomment the following property to allow adding DataSource dynamically.
 # dynamic.datasource.allowed-driver-classes={'org.h2.Driver','org.postgresql.Driver'}
+
+casdoor.endpoint=http://localhost:7001
+casdoor.client-id=3ed79fa530645fbd3653
+casdoor.client-secret=54633c82b7796a4332c6976864c6c16bc3b05556
+casdoor.certificate=\
+-----BEGIN CERTIFICATE-----\n\
+MIIE+TCCAuGgAwIBAgIDAeJAMA0GCSqGSIb3DQEBCwUAMDYxHTAbBgNVBAoTFENh\n\
+c2Rvb3IgT3JnYW5pemF0aW9uMRUwEwYDVQQDEwxDYXNkb29yIENlcnQwHhcNMjEx\n\
+MDE1MDgxMTUyWhcNNDExMDE1MDgxMTUyWjA2MR0wGwYDVQQKExRDYXNkb29yIE9y\n\
+Z2FuaXphdGlvbjEVMBMGA1UEAxMMQ2FzZG9vciBDZXJ0MIICIjANBgkqhkiG9w0B\n\
+AQEFAAOCAg8AMIICCgKCAgEAsInpb5E1/ym0f1RfSDSSE8IR7y+lw+RJjI74e5ej\n\
+rq4b8zMYk7HeHCyZr/hmNEwEVXnhXu1P0mBeQ5ypp/QGo8vgEmjAETNmzkI1NjOQ\n\
+CjCYwUrasO/f/MnI1C0j13vx6mV1kHZjSrKsMhYY1vaxTEP3+VB8Hjg3MHFWrb07\n\
+uvFMCJe5W8+0rKErZCKTR8+9VB3janeBz//zQePFVh79bFZate/hLirPK0Go9P1g\n\
+OvwIoC1A3sarHTP4Qm/LQRt0rHqZFybdySpyWAQvhNaDFE7mTstRSBb/wUjNCUBD\n\
+PTSLVjC04WllSf6Nkfx0Z7KvmbPstSj+btvcqsvRAGtvdsB9h62Kptjs1Yn7GAuo\n\
+I3qt/4zoKbiURYxkQJXIvwCQsEftUuk5ew5zuPSlDRLoLByQTLbx0JqLAFNfW3g/\n\
+pzSDjgd/60d6HTmvbZni4SmjdyFhXCDb1Kn7N+xTojnfaNkwep2REV+RMc0fx4Gu\n\
+hRsnLsmkmUDeyIZ9aBL9oj11YEQfM2JZEq+RVtUx+wB4y8K/tD1bcY+IfnG5rBpw\n\
+IDpS262boq4SRSvb3Z7bB0w4ZxvOfJ/1VLoRftjPbLIf0bhfr/AeZMHpIKOXvfz4\n\
+yE+hqzi68wdF0VR9xYc/RbSAf7323OsjYnjjEgInUtRohnRgCpjIk/Mt2Kt84Kb0\n\
+wn8CAwEAAaMQMA4wDAYDVR0TAQH/BAIwADANBgkqhkiG9w0BAQsFAAOCAgEAn2lf\n\
+DKkLX+F1vKRO/5gJ+Plr8P5NKuQkmwH97b8CS2gS1phDyNgIc4/LSdzuf4Awe6ve\n\
+C06lVdWSIis8UPUPdjmT2uMPSNjwLxG3QsrimMURNwFlLTfRem/heJe0Zgur9J1M\n\
+8haawdSdJjH2RgmFoDeE2r8NVRfhbR8KnCO1ddTJKuS1N0/irHz21W4jt4rxzCvl\n\
+2nR42Fybap3O/g2JXMhNNROwZmNjgpsF7XVENCSuFO1jTywLaqjuXCg54IL7XVLG\n\
+omKNNNcc8h1FCeKj/nnbGMhodnFWKDTsJcbNmcOPNHo6ixzqMy/Hqc+mWYv7maAG\n\
+Jtevs3qgMZ8F9Qzr3HpUc6R3ZYYWDY/xxPisuKftOPZgtH979XC4mdf0WPnOBLqL\n\
+2DJ1zaBmjiGJolvb7XNVKcUfDXYw85ZTZQ5b9clI4e+6bmyWqQItlwt+Ati/uFEV\n\
+XzCj70B4lALX6xau1kLEpV9O1GERizYRz5P9NJNA7KoO5AVMp9w0DQTkt+LbXnZE\n\
+HHnWKy8xHQKZF9sR7YBPGLs/Ac6tviv5Ua15OgJ/8dLRZ/veyFfGo2yZsI+hKVU5\n\
+nCCJHBcAyFnm1hdvdwEdH33jDBjNB6ciotJZrf/3VYaIWSalADosHAgMWfXuWP+h\n\
+8XKXmzlxuHbTMQYtZPDgspS5aK+S4Q9wb8RRAYo=\n\
+-----END CERTIFICATE-----
+casdoor.organization-name=built-in
+casdoor.application-name=sharding

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-frontend/src/views/login/casdoor.js
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-frontend/src/views/login/casdoor.js
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import API from './api'
+
+export default {
+  loginByCasdoor: () => {
+    // callback
+    const urlSearchParams = new URLSearchParams(window.location.search)
+    const params = {
+      code: urlSearchParams.get('code'),
+      state: urlSearchParams.get('state')
+    }
+    if (params.code != null && params.state != null) {
+      API.getCasdoorLogin(params).then(res => {
+        const data = res.model
+        const store = window.localStorage
+        store.setItem('Access-Token', data.accessToken)
+        store.setItem('username', data.username)
+        store.setItem('isGuest', data.isGuest)
+        location.href = '/#/registry-center'
+      })
+    }
+  }
+}

--- a/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-frontend/src/views/login/index.vue
+++ b/shardingsphere-elasticjob-lite-ui/shardingsphere-elasticjob-lite-ui-frontend/src/views/login/index.vue
@@ -56,6 +56,14 @@
           @click.native.prevent="handleLogin"
         >{{ $t("login.btnTxt") }}</el-button>
       </el-form-item>
+      <el-form-item class="btn-login">
+        <el-button
+          :loading="loading"
+          type="primary"
+          style="width:100%;"
+          @click.native.prevent="toLoginUrl()"
+        >{{ $t("Login with Casdoor") }}</el-button>
+      </el-form-item>
     </el-form>
     <s-footer style="position: fixed;bottom: 0;" />
   </div>
@@ -64,6 +72,9 @@
 <script>
 import SFooter from '../../components/Footer/index'
 import API from './api'
+import casdoor from './casdoor'
+
+casdoor.loginByCasdoor()
 export default {
   name: 'Login',
   components: {
@@ -105,6 +116,13 @@ export default {
         store.setItem('Access-Token', data.accessToken)
         store.setItem('username', data.username)
         location.href = '#/registry-center'
+      })
+    },
+    toLoginUrl() {
+    // redirect to casdoor login page
+      API.getCasdoorLoginUrl({ origin: window.location.origin }).then(res => {
+        const data = res.model
+        window.location.href = data.casdoorLoginUrl
       })
     }
   }


### PR DESCRIPTION
Use [Casdoor](https://github.com/casdoor/casdoor) for auth.

Features:

Support OIDC, OAuth 2.0, SAML, LDAP
With [Casbin](https://casbin.org/) based authorization management, Casdoor supports ACL, RBAC, ABAC, RESTful accessing control models
Front-end and back-end separate architecture, Casdoor supports high concurrency, provides web-based managing UI and have mature solution for springboot project https://casdoor.org/docs/integration/spring-boot
Casdoor supports Github, Google, QQ, WeChat third-party applications login, and support the extension of third-party login with plugins.
Phone verification code, email verification code and forget password features.
Accessing logs auditing and recording.
Casdoor supports integration with existing systems using db sync method, users can transition to Casdoor smoothly.
Casdoor supports mainstream databases: MySQL, PostgreSQL, SQL Server etc, and support the extension of new database with plugins.


Continue:https://github.com/apache/shardingsphere-elasticjob-ui/pull/151